### PR TITLE
Generic User Experience improvements

### DIFF
--- a/main/configuration.h
+++ b/main/configuration.h
@@ -33,15 +33,15 @@ void ttn_register(void (*callback)(uint8_t message));
 // -----------------------------------------------------------------------------
 
 #define APP_NAME                "TTN MAP-TRACK"
-#define APP_VERSION             "1.2.0"
+#define APP_VERSION             "1.2.1"
 
 // -----------------------------------------------------------------------------
 // Configuration
 // -----------------------------------------------------------------------------
 
 // Select which T-Beam board is being used. Only uncomment one.
-// #define T_BEAM_V07  // AKA Rev0 (first board released)
-#define T_BEAM_V10  // AKA Rev1 (second board released)
+#define T_BEAM_V07  // AKA Rev0 (first board released)
+// #define T_BEAM_V10  // AKA Rev1 (second board released)
 
 // Select the payload format. Change on TTN as well. Only uncomment one.
 #define PAYLOAD_USE_FULL
@@ -49,6 +49,12 @@ void ttn_register(void (*callback)(uint8_t message));
 
 // If using a single-channel gateway, uncomment this next option and set to your gateway's channel
 //#define SINGLE_CHANNEL_GATEWAY  0
+
+//Uncomment if you always want to see the boot logo at boot time
+#define ALWAYS_SHOW_LOGO
+
+//Uncomment to enable discarding network settings by long pressing second button
+//#define PREFS_DISCARD
 
 // If you are having difficulty sending messages to TTN after the first successful send,
 // uncomment the next option and experiment with values (~ 1 - 5)

--- a/main/main.ino
+++ b/main/main.ino
@@ -152,9 +152,16 @@ void sleep() {
 
 
 void callback(uint8_t message) {
-  if (EV_JOINING == message) screen_print("Joining TTN...\n");
+  bool ttn_joined = false;
   if (EV_JOINED == message) {
-    screen_print("TTN joined!\n");
+    ttn_joined = true;
+  }
+  if (EV_JOINING == message) {
+    if (ttn_joined) {
+      screen_print("TTN joining...\n");
+    } else {
+      screen_print("Joined TTN!\n");
+    }
   }
   if (EV_JOIN_FAILED == message) screen_print("TTN join failed\n");
   if (EV_REJOIN_FAILED == message) screen_print("TTN rejoin failed\n");
@@ -334,12 +341,17 @@ void setup() {
   gps_setup();
 
   // Show logo on first boot after removing battery
+
+#ifndef ALWAYS_SHOW_LOGO 
   if (bootCount == 0) {
+#endif
     screen_print(APP_NAME " " APP_VERSION, 0, 0);
     screen_show_logo();
     screen_update();
     delay(LOGO_DELAY);
-  }
+ #ifndef ALWAYS_SHOW_LOGO
+ }
+#endif
 
   // TTN setup
   if (!ttn_setup()) {
@@ -382,10 +394,15 @@ void loop() {
     wasPressed = false;
     if(millis() > minPressMs) {
       // held long enough
-      screen_print("Erasing prefs");
+#ifndef PREFS_DISCARD
+      screen_print("Discarding prefs disabled\n");
+#endif 
+#ifdef PREFS_DISCARD
+      screen_print("Discarding prefs!\n");
       ttn_erase_prefs();
       delay(5000); // Give some time to read the screen
       ESP.restart();
+#endif
     }
   }
 


### PR DESCRIPTION
- Avoid conflicting messages on joining versus joined TTN
- Enabled boot logo if ALWAYS_SHOW_LOGO is set
- Avoid accidentally pressing second button too long to discard network prefs. Set PREFS_DISCARD to enable